### PR TITLE
Reorder inclusion of check_existing.yml so route_host is set

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -12,10 +12,6 @@
     api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'
     kind: '{{ hostvars["localhost"]["inventory_file"].split("/")[6]  }}'
 
-- name: Check for existing {{ deployment_type }} deployment
-  ansible.builtin.include_tasks: check_existing.yml
-  when: gating_version | length
-
 - name: Fail execution if image_pull_secret or image_pull_secrets are defined but as NoneType ('image_pull_secret[s]:')
   fail:
     msg: "If image_pull_secret or image_pull_secrets will not be used, their declarations should be removed."
@@ -61,6 +57,10 @@
     set_fact:
       web_url: "https://{{ route_host }}"
   when: ingress_type | lower == 'route'
+
+- name: Check for existing {{ deployment_type }} deployment
+  ansible.builtin.include_tasks: check_existing.yml
+  when: gating_version | length
 
 - name: Configure Postgres Configuration Secret
   include_tasks: postgres_configuration.yml


### PR DESCRIPTION
##### SUMMARY

We need this diff to move the includes of these tasks to after when `route_host` is defined:

```diff
diff --git a/roles/common/tasks/main.yml b/roles/common/tasks/main.yml
index 3e7f40b..574bde9 100644
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -12,10 +12,6 @@
     api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'
     kind: '{{ hostvars["localhost"]["inventory_file"].split("/")[6]  }}'
 
-- name: Check for existing {{ deployment_type }} deployment
-  ansible.builtin.include_tasks: check_existing.yml
-  when: gating_version | length
-
 - name: Fail execution if image_pull_secret or image_pull_secrets are defined but as NoneType ('image_pull_secret[s]:')
   fail:
     msg: "If image_pull_secret or image_pull_secrets will not be used, their declarations should be removed."
@@ -62,6 +58,10 @@
       web_url: "https://{{ route_host }}"
   when: ingress_type | lower == 'route'
 
+- name: Check for existing {{ deployment_type }} deployment
+  ansible.builtin.include_tasks: check_existing.yml
+  when: gating_version | length
+
 - name: Configure Postgres Configuration Secret
   include_tasks: postgres_configuration.yml
 ```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
